### PR TITLE
Fix remove-then-add transaction bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.class
 *~
 *.swp
+*.iml
+*.idea

--- a/GameArena.java
+++ b/GameArena.java
@@ -357,7 +357,7 @@ public class GameArena
      * @return The number of objects ready to render
      */
 	public int getObjectCount() {
-	    return balls.size() + texts.size() + rectangles.size() + balls.size() + addList.size();
+	    return balls.size() + texts.size() + rectangles.size() + lines.size() + addList.size();
     }
 	
 	/**

--- a/GameArena.java
+++ b/GameArena.java
@@ -23,7 +23,7 @@ import java.awt.event.WindowEvent;
  * Instances of the Ball and Rectangle classes can be added to an instance of this class to
  * draw and animate simple shapes on the screen. 
  *
- * <b>Note: Patched to prevent mulitple render objects with the same key, thus losing the render object reference</b>
+ * <b>Note:</b> Patched to prevent mulitple render objects with the same key, thus losing the render object reference
  *
  * @see Ball
  * @see Rectangle

--- a/GameArena.java
+++ b/GameArena.java
@@ -376,7 +376,7 @@ public class GameArena
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(b);
-            if( !balls.containsKey(l) )
+            if( !balls.containsKey(b) )
                 addList.add(b);
             objectCount++;
 		}
@@ -468,7 +468,7 @@ public class GameArena
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(t);
-            if( !texts.containsKey(l) )
+            if( !texts.containsKey(t) )
                 addList.add(t);
             objectCount++;
 		}
@@ -514,7 +514,7 @@ public class GameArena
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(r);
-            if( !rectangles.containsKey(l) )
+            if( !rectangles.containsKey(r) )
                 addList.add(r);
             objectCount++;
 		}

--- a/GameArena.java
+++ b/GameArena.java
@@ -47,7 +47,6 @@ public class GameArena
     private Map<Rectangle, javafx.scene.shape.Rectangle> rectangles = new HashMap<>();
     private Map<Line, javafx.scene.shape.Line> lines = new HashMap<>();
     private Map<Text, javafx.scene.text.Text> texts = new HashMap<>();
-    private int objectCount;
 
     // Basic button state
 	private boolean up = false;
@@ -90,7 +89,6 @@ public class GameArena
 	{   
         this.arenaWidth = width;
         this.arenaHeight = height;
-        this.objectCount = 0;
         this.initialised = false;
         this.rendered = false;
 
@@ -196,7 +194,6 @@ public class GameArena
             balls.clear();
             lines.clear();
             texts.clear();
-            objectCount = 0;
             initialised = false;
 
             root.getChildren().clear();
@@ -351,6 +348,17 @@ public class GameArena
 		Color colour = Color.web(col);
 		return colour;
 	}
+
+    /**
+     * Sums the sizes of all internal object maps to produce a count of all currently rendered objects
+     *
+     * <b>Note: </b> This will be accurate between update()s, as it accounts for any on the add queue
+     *
+     * @return The number of objects ready to render
+     */
+	public int getObjectCount() {
+	    return balls.size() + texts.size() + rectangles.size() + balls.size() + addList.size();
+    }
 	
 	/**
 	 * Adds a given Ball to the GameArena. 
@@ -362,23 +370,21 @@ public class GameArena
 	{
 		synchronized (this)
 		{
-			if (objectCount > MAXIMUM_OBJECTS)
-			{
-				System.out.println("\n\n");
-				System.out.println(" ********************************************************* ");
-				System.out.println(" ***** Only 100000 Objects Supported per Game Arena! ***** ");
-				System.out.println(" ********************************************************* ");
-				System.out.println("\n");
-				System.out.println("-- Joe\n\n");
+			if (getObjectCount() > MAXIMUM_OBJECTS) {
+                System.out.println("\n\n");
+                System.out.println(" ********************************************************* ");
+                System.out.println(" ***** Only 100000 Objects Supported per Game Arena! ***** ");
+                System.out.println(" ********************************************************* ");
+                System.out.println("\n");
+                System.out.println("-- Joe\n\n");
 
                 System.exit(0);
-			}
+            }
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(b);
             if( !balls.containsKey(b) )
                 addList.add(b);
-            objectCount++;
 		}
 	}
 
@@ -394,7 +400,6 @@ public class GameArena
 		{
             addList.remove(b);
             removeList.add(b);
-            objectCount--;
 		}
 	}
 
@@ -408,7 +413,7 @@ public class GameArena
 	{
 		synchronized (this)
 		{
-			if (objectCount > MAXIMUM_OBJECTS)
+			if (getObjectCount() > MAXIMUM_OBJECTS)
 			{
 				System.out.println("\n\n");
 				System.out.println(" ********************************************************* ");
@@ -424,7 +429,6 @@ public class GameArena
             removeList.remove(l);
 			if( !lines.containsKey(l) )
                 addList.add(l);
-            objectCount++;
 		}
 	}
 
@@ -440,7 +444,6 @@ public class GameArena
 		{
             addList.remove(l);
             removeList.add(l);
-            objectCount--;
 		}
 	}
 
@@ -454,7 +457,7 @@ public class GameArena
 	{
 		synchronized (this)
 		{
-			if (objectCount > MAXIMUM_OBJECTS)
+			if (getObjectCount() > MAXIMUM_OBJECTS)
 			{
 				System.out.println("\n\n");
 				System.out.println(" ********************************************************* ");
@@ -470,7 +473,6 @@ public class GameArena
             removeList.remove(t);
             if( !texts.containsKey(t) )
                 addList.add(t);
-            objectCount++;
 		}
 	}
 
@@ -486,7 +488,6 @@ public class GameArena
 		{
             addList.remove(t);
             removeList.add(t);
-            objectCount--;
 		}
 	}
 
@@ -500,7 +501,7 @@ public class GameArena
 	{
 		synchronized (this)
 		{
-			if (objectCount > MAXIMUM_OBJECTS)
+			if (getObjectCount() > MAXIMUM_OBJECTS)
 			{
 				System.out.println("\n\n");
 				System.out.println(" ********************************************************* ");
@@ -516,7 +517,6 @@ public class GameArena
             removeList.remove(r);
             if( !rectangles.containsKey(r) )
                 addList.add(r);
-            objectCount++;
 		}
 	}
 
@@ -532,7 +532,6 @@ public class GameArena
 		{
             addList.remove(r);
             removeList.add(r);
-            objectCount--;
 		}
 	}
 

--- a/GameArena.java
+++ b/GameArena.java
@@ -23,6 +23,8 @@ import java.awt.event.WindowEvent;
  * Instances of the Ball and Rectangle classes can be added to an instance of this class to
  * draw and animate simple shapes on the screen. 
  *
+ * <b>Note: Patched to prevent mulitple render objects with the same key, thus losing the render object reference</b>
+ *
  * @see Ball
  * @see Rectangle
  *
@@ -374,7 +376,8 @@ public class GameArena
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(b);
-            addList.add(b);
+            if( !balls.containsKey(l) )
+                addList.add(b);
             objectCount++;
 		}
 	}
@@ -419,7 +422,8 @@ public class GameArena
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(l);
-            addList.add(l);
+			if( !lines.containsKey(l) )
+                addList.add(l);
             objectCount++;
 		}
 	}
@@ -464,7 +468,8 @@ public class GameArena
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(t);
-            addList.add(t);
+            if( !texts.containsKey(l) )
+                addList.add(t);
             objectCount++;
 		}
 	}
@@ -509,7 +514,8 @@ public class GameArena
 
             // Add this ball to the draw list. Initially, with a null JavaFX entry, which we'll fill in later to avoid cross-thread operations...
             removeList.remove(r);
-            addList.add(r);
+            if( !rectangles.containsKey(l) )
+                addList.add(r);
             objectCount++;
 		}
 	}


### PR DESCRIPTION
Fixes an bug whereby removing then re-adding the same external object reference without forcing an update causes a duplicate render copy-object to be produced, de-referencing the old one forever leaving it inaccessible to everything except the render area.

The patch simply checks that there isn't already a render object with the same external key before allowing the 'add' transaction into the add-list.