### PR TITLE
A function to clear all previously added objects to the GameArena.

### DIFF
--- a/GameArena.java
+++ b/GameArena.java
@@ -459,6 +459,15 @@ public class GameArena extends JPanel implements Runnable, KeyListener, MouseLis
 	}
 
 	/**
+	 * Removes every object that has ever been added to the GameArena. Nothing
+	 * should appear on the GameArena window after this has executed.
+	 */
+	public void clearGameArena() {
+		things.clear();
+	}
+
+
+	/**
 	 * Pause for a 1/50 of a second. 
 	 * This method causes your program to delay for 1/50th of a second. You'll find this useful if you're trying to animate your application.
 	 *


### PR DESCRIPTION
Since GameArena is already keeping track of what is added to it, it makes sense it should be able to remove everything with one function.

This implementation has been poorly tested, with only 2 different programs, but worked as expected for both them.